### PR TITLE
Delete previously generated files older than one day

### DIFF
--- a/image-converters/bulkpcl.sh
+++ b/image-converters/bulkpcl.sh
@@ -58,7 +58,7 @@ fi
 done
 
 # Remove old files 
-${ORACLE_HOME}/clean-old-files.sh
+${ORACLE_HOME}/clean-old-files.sh $1
 
 sleep 2
 done

--- a/image-converters/bulkpcl.sh
+++ b/image-converters/bulkpcl.sh
@@ -56,5 +56,9 @@ then
         fi
 fi
 done
+
+# Remove old files 
+${ORACLE_HOME}/clean-old-files.sh
+
 sleep 2
 done

--- a/image-converters/bulkpdf.sh
+++ b/image-converters/bulkpdf.sh
@@ -64,5 +64,9 @@ then
         fi
 fi
 done
+
+# Remove old files
+${ORACLE_HOME}/clean-old-files.sh
+
 sleep 2 
 done

--- a/image-converters/bulkpdf.sh
+++ b/image-converters/bulkpdf.sh
@@ -66,7 +66,7 @@ fi
 done
 
 # Remove old files
-${ORACLE_HOME}/clean-old-files.sh
+${ORACLE_HOME}/clean-old-files.sh $1
 
 sleep 2 
 done

--- a/image-converters/clean-old-files.sh
+++ b/image-converters/clean-old-files.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Remove files that have been previously created that are older than 1 day
+find efatt*$1.okkept -mtime +1 -exec rm {} \;
+find efatt*$1.tif -mtime +1 -exec rm {} \;
+find efatt*$1.failedtoconvert -mtime +1 -exec rm {} \;
+


### PR DESCRIPTION
The filesystem on the CHIPS EC2 instances is gradually being used up, and the largest contributor to the disk usage is the docker volume for EFAttachments.   This contains transient pcl, pdf and tif files that are submitted from electronic filings.

This change adds commands to continuously remove those files older than 1 day.

Resolves: https://companieshouse.atlassian.net/browse/CM-1395